### PR TITLE
Various fixes for ARM/NEON (and some additions)

### DIFF
--- a/gf256.h
+++ b/gf256.h
@@ -48,11 +48,10 @@
 // Library version
 #define GF256_VERSION 2
 
-
 //------------------------------------------------------------------------------
 // Platform/Architecture
 
-#if defined(ANDROID) || defined(IOS)
+#if defined(ANDROID) || defined(IOS) || defined(LINUX_ARM)
     #define GF256_TARGET_MOBILE
 #endif // ANDROID
 


### PR DESCRIPTION
First, using NEON, gf256_muladd_mem didn't pass self-tests. Fixed by
replacing vshrq_n_u8 by vshrq_n_u64, since it's the NEON equivalent of
_mm_srli_epi64, not vshrq_n_u8.

Also needed to add uint8_t* casts everywhere when calling vld1q_u8 or
vst1q_u8. Dirty, but it works. Kept my compiler happy. I'm not sure it's
the right thing to do, though.

Last, vqtbl1q_u8 is only available if ASIMD is available. Added a NEON
equivalent. That should be slower than its ASIMD counterpart of course,
but still is faster than no NEON optimization (more than 2x speed
increase on my Freescale SoC).

Also added support of runtime NEON support check for LINUX_ARM platform
(macro name might be misleading, maybe find another one).

Since I could not test on Android or IOS, I'm not sure if this breaks anything... 