### PR TITLE
Fix gf256_memswap in the GF256_TARGET_MOBILE case

### DIFF
--- a/gf256.cpp
+++ b/gf256.cpp
@@ -1459,6 +1459,7 @@ extern "C" void gf256_memswap(void * GF256_RESTRICT vx, void * GF256_RESTRICT vy
 
     x16 += count;
     y16 += count;
+    bytes -= count * 8;
 #else
     GF256_M128 * GF256_RESTRICT x16 = reinterpret_cast<GF256_M128 *>(vx);
     GF256_M128 * GF256_RESTRICT y16 = reinterpret_cast<GF256_M128 *>(vy);


### PR DESCRIPTION
The initial loop did not update the "bytes" variable to
reflect bytes already copied.  Therefore in the case where
"bytes & 8" is non-zero, the tail code would copy an extra
8 bytes beyond the end.