### PR TITLE
Fix compilation on Linux aarch64

### DIFF
--- a/gf256.h
+++ b/gf256.h
@@ -53,7 +53,7 @@
 //------------------------------------------------------------------------------
 // Platform/Architecture
 
-#if defined(ANDROID) || defined(IOS) || defined(LINUX_ARM) || defined(__powerpc__) || defined(__s390__)
+#if defined(ANDROID) || defined(IOS) || defined(LINUX_ARM) || defined(__powerpc__) || defined(__s390__) || defined(__aarch64__)
     #define GF256_TARGET_MOBILE
 #endif // ANDROID
 


### PR DESCRIPTION
Nothing defines LINUX_ARM, and since the README mentions the NEON 
optimization is a WIP, ﻿this assumes it shouldn't be used unless 
explicitly defined.  If that is incorrect and that code is ready, then I 
can change this to enable the NEON optimization on at least aarch64.
